### PR TITLE
Updated numbers generation for math captcha

### DIFF
--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -98,13 +98,11 @@ class fiRequest {
             $mathMinRange = $this->modx->getOption('mathMinRange',$this->config,10);
             $op1 = rand($mathMinRange,$mathMaxRange);
             $op2 = rand($mathMinRange,$mathMaxRange);
-            if ($op2 > $op1) { $t = $op2; $op2 = $op1; $op1 = $t; } /* swap so we always get positive #s */
             /* prevent numbers from being equal */
-            if ($op2 == $op1) {
-                while ($op2 == $op1) {
-                    $op2 = rand($mathMinRange,$mathMaxRange);
-                }
+            while ($op2 == $op1) {
+                $op2 = rand($mathMinRange,$mathMaxRange);
             }
+            if ($op2 > $op1) { $t = $op2; $op2 = $op1; $op1 = $t; } /* swap so we always get positive #s */
             $operators = array('+','-');
             $operator = rand(0,1);
             $this->modx->setPlaceholders(array(


### PR DESCRIPTION
If `$op1` is equal to `$op2` after the loop `$op2` can be greater than `$op1`, so initial condition about positive answer will be not met.
