### PR TITLE
Update ficountryoptions.class.php

### DIFF
--- a/core/components/formit/model/formit/module/ficountryoptions.class.php
+++ b/core/components/formit/model/formit/module/ficountryoptions.class.php
@@ -54,6 +54,7 @@ class fiCountryOptions extends fiModule {
             'country' => $this->modx->getOption('cultureKey', array(), 'us', true),
         ));
         $this->setOption('selectedKey',$this->getOption('useIsoCode',true,'isset') ? 'countryKey' : 'countryName');
+        $this->modx->lexicon->load('formit:default');
     }
 
     /**


### PR DESCRIPTION
Make this load the lexicons.
For the prioritized option there are 2 lexicons requested, but after adding the entries they didn't appear. I use the country listing on forms where no FormIt is used for the handling, so that would be the issue I gues.
