### PR TITLE
Fixed typo in adding of the attachments

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -436,8 +436,8 @@ class fiHooks {
 
         
         /* handle file fields */
+        $attachmentIndex = 0;
         foreach ($origFields as $k => $v) {
-            $attachmentIndex = 0;
             if (is_array($v) && !empty($v['tmp_name']) && isset($v['error']) && $v['error'] == UPLOAD_ERR_OK) {
                 if (empty($v['name'])) {
                     $v['name'] = 'attachment'.$attachmentIndex;


### PR DESCRIPTION
Each attachment without the name (not sure it's possible) will have same generated name `attachment0` without this fix.
