### PR TITLE
Added attachments for auto-reply and Added ability to use @CODE as tpl

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitautoresponder.php
+++ b/core/components/formit/elements/snippets/snippet.formitautoresponder.php
@@ -36,6 +36,7 @@ $mailFromName = $modx->getOption('fiarFromName',$scriptProperties,$modx->getOpti
 $mailSender = $modx->getOption('fiarSender',$scriptProperties,$modx->getOption('emailsender'));
 $mailSubject = $modx->getOption('fiarSubject',$scriptProperties,'[[++site_name]] Auto-Responder');
 $mailSubject = str_replace(array('[[++site_name]]','[[++emailsender]]'),array($modx->getOption('site_name'),$modx->getOption('emailsender')),$mailSubject);
+$fiarFiles = $modx->getOption('fiarFiles',$scriptProperties,false);
 $isHtml = $modx->getOption('fiarHtml',$scriptProperties,true);
 $toField = $modx->getOption('fiarToField',$scriptProperties,'email');
 $multiSeparator = $modx->getOption('fiarMultiSeparator',$formit->config,"\n");
@@ -80,6 +81,14 @@ $modx->mail->set(modMail::MAIL_SENDER,$hook->_process($mailSender,$placeholders)
 $modx->mail->set(modMail::MAIL_SUBJECT,$hook->_process($mailSubject,$placeholders));
 $modx->mail->address('to',$mailTo);
 $modx->mail->setHTML($isHtml);
+
+/* add attachments */
+if($fiarFiles){
+    $fiarFiles = explode(',', $fiarFiles);
+    foreach($fiarFiles AS $file){
+        $modx->mail->mailer->AddAttachment($file);
+    }
+}
 
 /* reply to */
 $emailReplyTo = $modx->getOption('fiarReplyTo',$scriptProperties,$mailFrom);

--- a/core/components/formit/model/formit/formit.class.php
+++ b/core/components/formit/model/formit/formit.class.php
@@ -218,7 +218,11 @@ class FormIt {
      */
     public function getChunk($name,$properties = array()) {
         $chunk = null;
-        if (!isset($this->chunks[$name])) {
+        if(substr($name, 0, 6) == "@CODE:"){
+            $content = substr($name, 6);
+            $chunk = $this->modx->newObject('modChunk');
+            $chunk->setContent($content);
+        } elseif (!isset($this->chunks[$name])) {
             if (!$this->config['debug']) {
                 $chunk = $this->modx->getObject('modChunk',array('name' => $name),true);
             }


### PR DESCRIPTION
Add comma-separated files (full path)

Example:
&fiarFiles=`/fakepath/file.pdf,/fakepath/file2.pdf`

Example @CODE: 
   &fiarTpl=`@CODE:<h1>Form test</h1><p>From:[[+name]] ([[+email]])</p>`
