### PR TITLE
Export unlimited items

### DIFF
--- a/assets/components/formit/js/mgr/widgets/forms.grid.js
+++ b/assets/components/formit/js/mgr/widgets/forms.grid.js
@@ -104,6 +104,7 @@ Ext.extend(FormIt.grid.Forms,MODx.grid.Grid,{
                 ,context_key: Ext.getCmp('context').getValue()
                 ,startDate: Ext.getCmp('startdate').getValue()
                 ,endDate: Ext.getCmp('enddate').getValue()
+                ,limit: 0
             }
             ,listeners: {
                 'success': {fn:function(r) {


### PR DESCRIPTION
The export did not set a limit, so it was only 20 items long per default, which just does not make sense.
Maybe limiting the export would be a feature, but as long at this is not abailable, there should not be any limit.
Setting the limit to "0" gives you the whole thing. So you get what you ordered: an export of everything.
