### PR TITLE
JSON output options for errors and hooks

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -92,7 +92,7 @@ class fiHooks {
             'mathOp1Field' => 'op1',
             'mathOp2Field' => 'op2',
             'mathOperatorField' => 'operator',
-            'jsonOutputPlaceholder' => ''
+            'hookErrorJsonOutputPlaceholder' => ''
         ),$config);
         $this->type = $type;
     }
@@ -693,6 +693,7 @@ class fiHooks {
     public function processErrors() {
         $errors = array();
         $jsonerrors = array();
+        $jsonOutputPlaceholder = $this->config['hookErrorJsonOutputPlaceholder'];
         if (!empty($jsonOutputPlaceholder)) {
             $jsonerrors = array(
                 'errors' => array(),

--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -92,6 +92,7 @@ class fiHooks {
             'mathOp1Field' => 'op1',
             'mathOp2Field' => 'op2',
             'mathOperatorField' => 'operator',
+            'jsonOutputPlaceholder' => ''
         ),$config);
         $this->type = $type;
     }
@@ -691,16 +692,34 @@ class fiHooks {
      */
     public function processErrors() {
         $errors = array();
+        $jsonerrors = array();
+        if (!empty($jsonOutputPlaceholder)) {
+            $jsonerrors = array(
+                'errors' => array(),
+                'success' => false,
+                'message' => '',
+            );
+        }
+        
         $placeholderErrors = $this->getErrors();
         foreach ($placeholderErrors as $key => $error) {
             $errors[$key] = str_replace('[[+error]]',$error,$this->config['errTpl']);
+            if (!empty($jsonOutputPlaceholder)) $jsonerrors['errors'][$key] = $errors[$key];
         }
         $this->modx->toPlaceholders($errors,$this->config['placeholderPrefix'].'error');
 
         $errorMsg = $this->getErrorMessage();
         if (!empty($errorMsg)) {
             $this->modx->setPlaceholder($this->config['placeholderPrefix'].'error_message',$errorMsg);
+            if (!empty($jsonOutputPlaceholder)) {
+                $jsonerrors['message'] = $errorMsg;
+            }
         }
+        if (!empty($jsonOutputPlaceholder)) {
+            $jsonoutput = $this->modx->toJSON($jsonerrors);
+            $this->modx->setPlaceholder($jsonOutputPlaceholder,$jsonoutput);
+        }
+        
     }
 
     /**

--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -717,12 +717,18 @@ class fiValidator {
     public function processErrors() {
         $this->modx->toPlaceholders($this->getErrors(),$this->config['placeholderPrefix'].'error');
         $bulkErrTpl = $this->getOption('validationErrorBulkTpl');
+        $rawErrs = $this->getRawErrors();
         $errs = array();
-        foreach ($this->getRawErrors() as $field => $err) {
-            $errs[] = str_replace(array('[[+field]]','[[+error]]'),array($field,$err),$bulkErrTpl);
-        }
         $formatJson = $this->getOption('validationErrorBulkFormatJson');
-        $errs = ($formatJson) ? $this->modx->toJSON($errs) : implode($this->getOption('validationErrorBulkSeparator'),$errs);
+        if ($formatJson) {
+            $errs = '';
+            $errs = $this->modx->toJSON($rawErrs);
+        } else {
+            foreach ($rawErrs as $field => $err) {
+                $errs[] = str_replace(array('[[+field]]','[[+error]]'),array($field,$err),$bulkErrTpl);
+            }
+            $errs = implode($this->getOption('validationErrorBulkSeparator'),$errs);
+        }
         $validationErrorMessage = str_replace('[[+errors]]',$errs,$this->getOption('validationErrorMessage'));
         $this->modx->setPlaceholder($this->getOption('placeholderPrefix').'validation_error',true);
         $this->modx->setPlaceholder($this->getOption('placeholderPrefix').'validation_error_message',$validationErrorMessage);

--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -68,6 +68,7 @@ class fiValidator {
             'placeholderPrefix' => 'fi.',
             'validationErrorBulkTpl' => '<li>[[+error]]</li>',
             'validationErrorBulkSeparator' => "\n",
+            'validationErrorBulkFormatJson' => false,
             'validationErrorMessage' => '<p class="error">A form validation error occurred. Please check the values you have entered.</p>',
             'use_multibyte' => (boolean)$this->modx->getOption('use_multibyte',null,false),
             'trimValuesBeforeValidation' => (boolean)$this->modx->getOption('trimValuesBeforeValidation',$this->formit->config,true),
@@ -720,7 +721,8 @@ class fiValidator {
         foreach ($this->getRawErrors() as $field => $err) {
             $errs[] = str_replace(array('[[+field]]','[[+error]]'),array($field,$err),$bulkErrTpl);
         }
-        $errs = implode($this->getOption('validationErrorBulkSeparator'),$errs);
+        $formatJson = $this->getOption('validationErrorBulkFormatJson');
+        $errs = ($formatJson) ? $this->modx->toJSON($errs) : implode($this->getOption('validationErrorBulkSeparator'),$errs);
         $validationErrorMessage = str_replace('[[+errors]]',$errs,$this->getOption('validationErrorMessage'));
         $this->modx->setPlaceholder($this->getOption('placeholderPrefix').'validation_error',true);
         $this->modx->setPlaceholder($this->getOption('placeholderPrefix').'validation_error_message',$validationErrorMessage);


### PR DESCRIPTION
## What It Does

Allows formatting of error responses in JSON rather than HTML. Hooks class and Validator class affected.
## Why It's Needed

Often it's desirable for FormIt to handle form data posted via AJAX, and the response should be valid JSON instead of HTML. You can monkey around with conditional output modifiers and TPL properties, but in the end it's still very limiting and inflexible. With this PR, some runtime config options can be used to output these responses in JSON easily.
## Example Usage

```
[[!FormIt? 
    &hooks=`FormItSaveForm`
    &formName=`[[!getFormName]]`
    &validate=`type:required,email:email:required`
    &successMessage=`Thank you! Your request has been submitted.`
    &validationErrorBulkFormatJson=`1`
    &validationErrorMessage=`{"success":false,"errors":[[+errors]]}`
    &hookErrorJsonOutputPlaceholder=`hook_error_json_response`
    &errTpl=`[[+error]]`
]][[!+fi.validation_error_message]][[!+hook_error_json_response]]
[[!+fi.successMessage:is=``:then=``:else=`{"success":true,"message":"[[!+fi.successMessage]]"}`]]
```

If the hook returned an error it would be like this:

```
{
  "errors": {
    "test": "bad kitty!",
    "FormItSaveForm": " "
  },
  "success": false,
  "message": "bad kitty!\n "
}
```

If a validator failed it would look like this:

```
{
  "success": false,
  "errors": {
    "type": "This field is required.",
    "email": "This field is required."
  }
}
```
