### PR TITLE
Some fixes

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -66,7 +66,7 @@ $modx->setLogTarget('ECHO');
 $modx->loadClass('transport.modPackageBuilder','',false, true);
 $builder = new modPackageBuilder($modx);
 $builder->createPackage(PKG_ABBR,PKG_VERSION,PKG_RELEASE);
-$builder->registerNamespace(PKG_ABBR,false,true,'{core_path}components/'.PKG_ABBR.'/');
+$builder->registerNamespace(PKG_ABBR,false,true,'{core_path}components/'.PKG_ABBR.'/','{assets_path}components/'.PKG_ABBR.'/');
 
 /* create category */
 $category= $modx->newObject('modCategory');

--- a/assets/components/formit/js/mgr/formit.js
+++ b/assets/components/formit/js/mgr/formit.js
@@ -27,7 +27,7 @@ Ext.onReady(function() {
                 this.dateRangeMax = date;
             }
             else if (field.endDateField && (!this.dateRangeMin || (date.getTime() != this.dateRangeMin.getTime()))) {
-            	console.log(field)
+            	console.log(field);
                 var end = Ext.getCmp(field.endDateField);
                 end.setMinValue(date);
                 end.validate();
@@ -40,7 +40,7 @@ Ext.onReady(function() {
             return true;
         },
 
-        daterangeText: 'Start date must be less than end date',
+        daterangeText: 'Start date must be less than end date'
 
     });
 });

--- a/assets/components/formit/js/mgr/widgets/forms.grid.js
+++ b/assets/components/formit/js/mgr/widgets/forms.grid.js
@@ -113,7 +113,6 @@ Ext.extend(FormIt.grid.Forms,MODx.grid.Grid,{
  
         var win = window.open(_link, '_blank');
         win.focus();
-        return;
     }
 
 });

--- a/assets/components/formit/js/mgr/widgets/home.panel.js
+++ b/assets/components/formit/js/mgr/widgets/home.panel.js
@@ -43,7 +43,7 @@ FormIt.panel.Home = function(config) {
                             select: {
                                 scope: this,
                                 fn: function(contextField, Obj) {
-                                    Ext.getCmp('formit-grid-forms').baseParams.context_key = Obj.data.key
+                                    Ext.getCmp('formit-grid-forms').baseParams.context_key = Obj.data.key;
                                     Ext.getCmp('formit-grid-forms').getBottomToolbar().changePage(1);
                                     Ext.getCmp('formit-grid-forms').refresh();
                                 }
@@ -67,7 +67,7 @@ FormIt.panel.Home = function(config) {
                             select: {
                                 scope: this,
                                 fn: function(formField, Obj) {
-                                    Ext.getCmp('formit-grid-forms').baseParams.form = Obj.data.form
+                                    Ext.getCmp('formit-grid-forms').baseParams.form = Obj.data.form;
                                     Ext.getCmp('formit-grid-forms').getBottomToolbar().changePage(1);
                                     Ext.getCmp('formit-grid-forms').refresh();
                                 }

--- a/core/components/formit/lexicon/en/mgr.inc.php
+++ b/core/components/formit/lexicon/en/mgr.inc.php
@@ -53,4 +53,3 @@ $_lang['formit.form_encrypt'] = 'Encrypt';
 $_lang['formit.form_encrypt_confirm'] = 'Are you sure you want to encrypt all the submitted forms?';
 $_lang['formit.form_decrypt'] = 'Decrypt';
 $_lang['formit.form_decrypt_confirm'] = 'Are you sure you want to decrypt all the submitted forms?';
-$_lang['formit.'] = 'FormIt';

--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -94,7 +94,7 @@ class fiRequest {
         }
 
         /* if using math hook, load default placeholders */
-        if ($this->hasHook('math') && !$this->hasSubmission()) {
+        if ($this->hasHook('math')) {
             $mathMaxRange = $this->modx->getOption('mathMaxRange',$this->config,100);
             $mathMinRange = $this->modx->getOption('mathMinRange',$this->config,10);
             $op1 = rand($mathMinRange,$mathMaxRange);

--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -204,7 +204,7 @@ class fiValidator {
 
         /* htmlspecialchars by default */
         if ($replaceSpecialChars && !is_array($v)) {
-            $v = htmlspecialchars($v);
+            $v = htmlspecialchars($v, ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
         }
 
         /* handle checkboxes/radios with empty hiddens before that are field[] names */

--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -193,6 +193,20 @@ class fiValidator {
             $v = strip_tags($v);
         }
 
+        $replaceSpecialChars = strpos($k,'allowSpecialChars') === false;
+        if (isset($fieldValidators[$k])) {
+            foreach ($fieldValidators[$k] as $fv) {
+                if (strpos($fv,'allowSpecialChars') !== false) {
+                    $replaceSpecialChars = false;
+                }
+            }
+        }
+
+        /* htmlspecialchars by default */
+        if ($replaceSpecialChars && !is_array($v)) {
+            $v = htmlspecialchars($v);
+        }
+
         /* handle checkboxes/radios with empty hiddens before that are field[] names */
         if (is_array($v) && !isset($_FILES[$key[0]]) && empty($v[0])) array_splice($v,0,1);
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
 # FormIt
 
-FormIt is currently maintained at [modxcms/FormIt](http://github.com/modxcms/FormIt). Please [go there](http://github.com/modxcms/FormIt).
+FormIt is a dynamic form processing Snippet for MODx Revolution. It handles a form after submission, performing validation and followup actions like sending an email. It does not generate the form, but it can repopulate it if it fails validation.


### PR DESCRIPTION
The most important one is avoiding XSS attacks by htmlspecialchars. I really don't know why this issue could stay that long in the code. FormIt contains only a strip_tags securing its fields (a bit).

Without that patch you could create XSS attacks by posting `xsstest=%22+onMouseOver%3D%22alert%281%29%3B` to a form with the following input

```
<input id="xsstest" name="xsstest" type="text" value="[[!+fi.xsstest]]">
```

It contains the following text after

```
<input id="xsstest" name="xsstest" type="text" value="" onMouseOver="alert(1);">
```
