### PR TITLE
Add fiarRequired snippet property

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitautoresponder.php
+++ b/core/components/formit/elements/snippets/snippet.formitautoresponder.php
@@ -41,9 +41,14 @@ $isHtml = $modx->getOption('fiarHtml',$scriptProperties,true);
 $toField = $modx->getOption('fiarToField',$scriptProperties,'email');
 $multiSeparator = $modx->getOption('fiarMultiSeparator',$formit->config,"\n");
 $multiWrapper = $modx->getOption('fiarMultiWrapper',$formit->config,"[[+value]]");
+$required = $modx->getOption('fiarRequired',$scriptProperties,true);
 if (empty($fields[$toField])) {
-    $modx->log(modX::LOG_LEVEL_ERROR,'[FormIt] Auto-responder could not find field `'.$toField.'` in form submission.');
-    return false;
+    if ($required) {
+        $modx->log(modX::LOG_LEVEL_ERROR,'[FormIt] Auto-responder could not find field `'.$toField.'` in form submission.');
+        return false;
+    } else {
+        return true;
+    }
 }
 
 /* handle checkbox and array fields */


### PR DESCRIPTION
### What does it do?

Add an new snippet property fiarRequired. If it is set to false, the hook does not stop if $fields[$toField] is not set.
### Why is it needed?

At the moment the the email field has to be filled if the fiar hook is executed. The field can't be optional.
