### PR TITLE
making emailFrom not set by email field

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -348,7 +348,7 @@ class fiHooks {
         /* get from name */
         $emailFrom = $this->modx->getOption('emailFrom',$this->formit->config,'');
         if (empty($emailFrom)) {
-            $emailFrom = !empty($fields['email']) ? $fields['email'] : $this->modx->getOption('emailsender');
+            $emailFrom = $this->modx->getOption('emailsender');
         }
         $emailFrom = $this->_process($emailFrom,$fields);
         $emailFromName = $this->modx->getOption('emailFromName',$this->formit->config,$emailFrom);


### PR DESCRIPTION
It is odd and unexpected that if you have a form that accepts a user to input their email that the email they receive would be sent "from" their email address.

**NOTE: This may be considered a breaking change depending on how you look at it**

See Sterc/FormIt#101
