### PR TITLE
emailFromName fallback to site_name

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -351,7 +351,7 @@ class fiHooks {
             $emailFrom = !empty($fields['email']) ? $fields['email'] : $this->modx->getOption('emailsender');
         }
         $emailFrom = $this->_process($emailFrom,$fields);
-        $emailFromName = $this->modx->getOption('emailFromName',$this->formit->config,$emailFrom);
+        $emailFromName = $this->modx->getOption('emailFromName',$this->formit->config,$this->modx->getOption('site_name', $this->formit->config, $this->modx->getOption('site_name', null, $emailFrom)));
         $emailFromName = $this->_process($emailFromName,$fields);
 
         /* get returnPath */


### PR DESCRIPTION
first looks for `emailFromName` in settings
then in `$this->formit->config`
then looks for `site_name` in settings

finally falls back to `$emailFrom`

**NOTE: This may be considered a breaking change depending on how you look at it**

See Sterc/FormIt#101
