### PR TITLE
Fix bug with multiple file upload

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -458,7 +458,7 @@ class fiHooks {
         $attachmentIndex = 0;
         foreach ($origFields as $k => $v) {
             if (is_array($v) && !empty($v['tmp_name'])) {
-                if(count($v['name']) > 1){
+                 if(is_array($v['name'])){
                     for($i=0;$i<count($v['name']);++$i){
                         if(isset($v['error'][$i]) && $v['error'][$i] == UPLOAD_ERR_OK){
                             if (empty($v['name'][$i])) {


### PR DESCRIPTION
oK, if i use array with one element to upload file - your condition don't work. We need check array it or not. No need check count of elements.
