### PR TITLE
Fix problem with array values in mail chunks #139

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -428,7 +428,7 @@ class fiHooks {
                 $multiWrapper = '[[+value]]';
             }
             
-            foreach ($fields as $k => $v) {
+            foreach ($fields as $k => &$v) {
                 if (is_array($v) && !empty($v['name']) && isset($v['error']) && $v['error'] == UPLOAD_ERR_OK) {
                     $v = $v['name'];
                 } elseif (is_array($v)) {


### PR DESCRIPTION
The foreach by reference can't be changed that way, because the $v value is changed inside of the loop. 