### PR TITLE
Email output update for PHP 7.1

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -384,7 +384,7 @@ class fiHooks {
         $origFields = $fields;
         if (empty($tpl)) {
             $tpl = 'fiDefaultEmailTpl';
-            $f = '';
+            $f = array();
             $multiSeparator = $this->modx->getOption('emailMultiSeparator', $this->formit->config, "\n");
             $multiWrapper = $this->modx->getOption('emailMultiWrapper', $this->formit->config, "[[+value]]");
 


### PR DESCRIPTION
This is the fix described in #148, changing the type of `$f` from a string to an array. 