### PR TITLE
Bug on hasHook()

### DIFF
--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -164,7 +164,7 @@ class fiRequest {
      * @return boolean
      */
     public function hasHook($hook) {
-        return strpos($this->config['hooks'],$hook) !== false;
+        return !!preg_match('#\\b' . preg_quote($hook, '#') . '\\b#i', $this->config['hooks']);
     }
 
     /**


### PR DESCRIPTION
(boolean) function hasHook()

Using strpos() to evaluate hooks is very unreliable, as it is prone to hook collision. For example when using ReCaptchaV2 as hooks, its generates an error because FormIt automatically tries to load the ReCaptcha class.

See [MODx Forum thread/103830](https://forums.modx.com/thread/103830/recaptchav2-issue---formit-still-trying-to-load-built-in-recaptchav1#dis-post-559933)