### PR TITLE
Update snippet.formitloadsavedform.php

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitloadsavedform.php
+++ b/core/components/formit/elements/snippets/snippet.formitloadsavedform.php
@@ -64,7 +64,8 @@ if ($formFields) {
 // Initialize the data array
 // Handle encryption
 if ($formEncrypt) {
-    $data = $savedForm->decrypt();
+    $encrypted_data = $savedForm->get('values');
+    $data = $savedForm->decrypt($encrypted_data);
 } else {
     $data = $savedForm->get('values');
 }


### PR DESCRIPTION
In order to load previously saved forms which are encrypted, decrypt() should have the encrypted data from the database.