### PR TITLE
Add a MODX/PHP version check

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -507,6 +507,16 @@
             "FormItForm"
         ]
     },
+  "dependencies": [
+    {
+      "name": "php",
+      "version": ">=5.4"
+    },
+    {
+      "name": "php",
+      "version": ">=2.6"
+    }
+  ],
     "build": {
         "readme": "docs/readme.txt",
         "license": "docs/license.txt",

--- a/_build/config.json
+++ b/_build/config.json
@@ -513,7 +513,7 @@
       "version": ">=5.4"
     },
     {
-      "name": "php",
+      "name": "modx",
       "version": ">=2.6"
     }
   ],


### PR DESCRIPTION
It is available yet but is improved here: https://github.com/modxcms/revolution/pull/14255

The check is needed because of the namespace and new array syntax.