### PR TITLE
Add back the possibility to export all forms

### DIFF
--- a/assets/components/formit/js/mgr/widgets/forms.grid.js
+++ b/assets/components/formit/js/mgr/widgets/forms.grid.js
@@ -475,7 +475,7 @@ FormIt.window.ExportForms = function(config) {
             description : MODx.expandHelp ? '' : _('formit.label_export_form_desc'),
             name        : 'form',
             anchor      : '100%',
-            allowBlank  : false
+            allowBlank  : true
         }, {
             xtype       : MODx.expandHelp ? 'label' : 'hidden',
             html        : _('formit.label_export_form_desc'),


### PR DESCRIPTION
In earlier versions it was possible to export all forms by leaving the "form" selection blank. 