### PR TITLE
remove php notice message

### DIFF
--- a/core/components/formit/src/FormIt/Hook.php
+++ b/core/components/formit/src/FormIt/Hook.php
@@ -144,7 +144,7 @@ class Hook
             $properties['formit'] =& $this->formit;
             $properties['hook'] =& $this;
             $properties['fields'] = $this->fields;
-            $properties['errors'] =& array_merge($errors, $this->errors);
+            $properties['errors'] = array_merge($errors, $this->errors);
             $success = $snippet->process($properties);
         } else {
             /* search for a file-based hook */


### PR DESCRIPTION
remove message in the log
.../core/components/formit/src/FormIt/Hook.php : 148) PHP notice: Only variables should be assigned by reference