### PR TITLE
Fix the path to clean processor for cronjob

### DIFF
--- a/assets/components/formit/cronjob/cron.php
+++ b/assets/components/formit/cronjob/cron.php
@@ -21,7 +21,7 @@ $modx->lexicon->load('formit:default');
 
 /* handle request */
 $path = $modx->getOption('processorsPath', $modx->formit->config, $corePath.'processors/');
-$response = $modx->runProcessor('mgr/form/clean', [], [
+$response = $modx->runProcessor('mgr/forms/clean', [], [
     'processors_path' => $path
 ]);
 


### PR DESCRIPTION
The path to the clean processor within the cronjob file is incorrect.