### PR TITLE
Adds support for UTF-8 encoding when exporting

### DIFF
--- a/core/components/formit/processors/mgr/forms/export.class.php
+++ b/core/components/formit/processors/mgr/forms/export.class.php
@@ -257,8 +257,12 @@ class FormItFormExportProcessor extends modProcessor
             $content = file_get_contents($file);
 
             if ($content) {
+                header('Content-Encoding: UTF-8');
                 header('Content-Type: application/force-download');
                 header('Content-Disposition: attachment; filename="' . $this->getProperty('filename') . '"');
+                header("Pragma: no-cache");
+                header("Expires: 0");
+                echo "\xEF\xBB\xBF"; // UTF-8 BOM
 
                 return $content;
             }


### PR DESCRIPTION
Adds support for UTF-8 encoding when exporting a form

Before:
![image](https://user-images.githubusercontent.com/2138260/70798357-eb853480-1dd0-11ea-8650-82300732d228.png)

After: 
![image](https://user-images.githubusercontent.com/2138260/70798349-e58f5380-1dd0-11ea-9914-c289daae0cf4.png)

