### PR TITLE
Add emailSelect... properties to the email hook

### DIFF
--- a/core/components/formit/src/FormIt/Hook/Email.php
+++ b/core/components/formit/src/FormIt/Hook/Email.php
@@ -53,6 +53,9 @@ class Email
      *  emailFromName - The name of the From: user.
      *  emailSubject - The subject of the email.
      *  emailHtml - Boolean, if true, email will be in HTML mode.
+     *  emailSelectField - The name of the form field, that selects the email addresses to send to.
+     *  emailSelectTo - A semicolon separated list of comma separated email addresses to send to.
+     *  emailSelectToName - A semicolon separated list of comma separated email names to send to.
      *
      * @param array $fields An array of cleaned POST fields
      *
@@ -88,6 +91,22 @@ class Email
             $subject = $this->modx->getOption('emailSubject', $this->formit->config, '');
         }
         $subject = $this->hook->_process($subject, $fields);
+
+        /* select email to */
+        $emailSelectTo = $this->modx->getOption('emailSelectTo', $this->formit->config, '');
+        $emailSelectTo = ($emailSelectTo) ? explode(';', $emailSelectTo) : array();
+        $emailSelectToName = $this->modx->getOption('emailSelectToName', $this->formit->config, $emailSelectTo);
+        $emailSelectToName = ($emailSelectToName) ? explode(';', $emailSelectToName) : array();
+        $emailSelectField = $this->modx->getOption('emailSelectField', $this->formit->config, '');
+        if ($emailSelectField && isset($fields[$emailSelectField])) {
+            $selected = intval($fields[$emailSelectField]);
+            if ($selected && isset($emailSelectTo[$selected - 1])) {
+                $this->formit->config['emailTo'] = $emailSelectTo[$selected - 1];
+            }
+            if ($selected && isset($emailSelectToName[$selected - 1])) {
+                $this->formit->config['emailToName'] = $emailSelectToName[$selected - 1];
+            }
+        }
 
         /* check email to */
         $emailTo = $this->modx->getOption('emailTo', $this->formit->config, '');


### PR DESCRIPTION
### What does it do?
Add emailSelectTo, emailSelectToName and emailSelectField properties to the email hook

### Why is it needed?
To avoid to enter the email addresses directly in the dropdown option values

Usage:
```
&emailSelectTo=`mail@my.domain;different@my.domain`
&emailSelectToName=`Name 1;Name 2`
&emailSelectField=`emailselect`
```

Form Field:
```
<select name="emailselect">
    <option value="1" [[!+fi.emailselect:FormItIsSelected=`1`]]>Address 1</option>
    <option value="2" [[!+fi.emailselect:FormItIsSelected=`2`]]>Address 2</option>
</select>
```

### Related issue(s)/PR(s)
Bugfix for #216