### PR TITLE
Call to a member function isError() on string

### DIFF
--- a/assets/components/formit/cronjob/cron.php
+++ b/assets/components/formit/cronjob/cron.php
@@ -25,6 +25,8 @@ $response = $modx->runProcessor('mgr/forms/clean', [], [
     'processors_path' => $path
 ]);
 
-if ($response->isError()) {
-    print $response->getMessage();
+if(!empty($response)){ 
+    if ($response->isError()) {
+        print $response->getMessage();
+    }
 }


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught Error: Call to a member function isError() on string in /www/assets/components/formit/cronjob/cron.php:28
Stack trace:
#0 {main}
  thrown in /www/assets/components/formit/cronjob/cron.php on line 28
/paas/c0061/home $ php www/assets/components/formit/cronjob/cron.php
```

### What does it do?
Fix Fatal error. Because when I test it - I get STRING "" in response (Modx3 , last FormIt) 
