### PR TITLE
Put the limit in the query

### DIFF
--- a/core/components/formit/processors/mgr/forms/migrate.class.php
+++ b/core/components/formit/processors/mgr/forms/migrate.class.php
@@ -24,12 +24,10 @@ class FormItMigrateProcessor extends modProcessor
             'encrypted' => 1,
             'encryption_type' => 1
         ));
+        $c->limit($limit);
         $collection = $this->modx->getIterator('FormItForm', $c);
 
         foreach ($collection as $form) {
-            if ($count > $limit) {
-                break;
-            }
             $oldValues = $form->get('values');
             $oldValues = $form->decrypt($oldValues, 1);
             /* Fix for when forms are encrypted with openssl, but encryption_type field is not set to 2 */


### PR DESCRIPTION
### What does it do?
Put the limit in the query instead of breaking the foreach loop

### Why is it needed?
To avoid errors like 
```
Array
(
    [0] => HY000
    [1] => 2014
    [2] => Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.
)
```

> opengeek: It happens when you do a fetch on a PDOStatement but never finish getting all the rows you have to fetch until the result set is completely iterated or manually closeCursor() on the statement

### Related issue(s)/PR(s)
None
