### PR TITLE
Don't reset $modx->mail in the autoresponder

### DIFF
--- a/core/components/formit/src/FormIt/Hook/Autoresponder.php
+++ b/core/components/formit/src/FormIt/Hook/Autoresponder.php
@@ -129,7 +129,6 @@ class Autoresponder
         $this->modx->parser->processElementTags('', $message, true, false);
 
         $this->modx->getService('mail', 'mail.modPHPMailer');
-        $this->modx->mail->reset();
         $this->modx->mail->set(\modMail::MAIL_BODY, $message);
         $this->modx->mail->set(\modMail::MAIL_FROM, $this->hook->_process($mailFrom, $placeholders));
         $this->modx->mail->set(\modMail::MAIL_FROM_NAME, $this->hook->_process($mailFromName, $placeholders));


### PR DESCRIPTION
### What does it do?
Don't reset $modx->mail in the autoresponder.

### Why is it needed?
The autoresponder could have string based attachments with the following code in a hook before FormItAutoResponder without the reset.

```
    $pdf = …

    /** $mail modPHPMailer */
    $hook->modx->getService('mail', 'mail.modPHPMailer');
    $hook->modx->mail->mailer->addStringAttachment($pdf, 'attachment.pdf');
```

Since $modx->mail is reset in the email hook (https://github.com/Sterc/FormIt/blob/develop/core/components/formit/src/FormIt/Hook/Email.php#L315-L318), the reset is not necessary in the autoresponder. 

### Related issue(s)/PR(s)
none