### PR TITLE
Update autoloader

### DIFF
--- a/core/components/formit/vendor/composer/ClassLoader.php
+++ b/core/components/formit/vendor/composer/ClassLoader.php
@@ -60,7 +60,7 @@ class ClassLoader
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
-            return call_user_func_array('array_merge', $this->prefixesPsr0);
+            return call_user_func_array('array_merge', array_values($this->prefixesPsr0));
         }
 
         return array();
@@ -279,7 +279,7 @@ class ClassLoader
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && ini_get('apc.enabled') ? $apcuPrefix : null;
+        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
 
     /**
@@ -377,11 +377,11 @@ class ClassLoader
             $subPath = $class;
             while (false !== $lastPos = strrpos($subPath, '\\')) {
                 $subPath = substr($subPath, 0, $lastPos);
-                $search = $subPath.'\\';
+                $search = $subPath . '\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
+                    $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        $length = $this->prefixLengthsPsr4[$first][$search];
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
+                        if (file_exists($file = $dir . $pathEnd)) {
                             return $file;
                         }
                     }

--- a/core/components/formit/vendor/composer/autoload_real.php
+++ b/core/components/formit/vendor/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitf04f5acd9d2ed29ec2c783dd1c99d56e
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {


### PR DESCRIPTION
### What does it do?

Re-ran `composer install` to update the autoloader with Composer 1.10.19, while the current version appears to be built with v1.6-1.8-ish.

### Why is it needed?

Diving into the rabbit hole of #179 and https://community.modx.com/t/500-bounty-autoloaders-from-different-packages-being-ignored/3099 turned up older autoloaders having a different ClassLoader class which appears to have caused the issue. 

While most of the problems described in that forum thread use modmore extras and we've pinpointed an issue in our own build process today that I've corrected and am rolling out, there have also been users experiencing this problem _without_ modmore extras that do seem to have FormIt in common, so updating the autoloader seems like it would be an important step for such a popular extra. In the case of FormIt, the vendor directory is committed and the autoloader hardcoded, so that's a needs a manual bump.

### Related issue(s)/PR(s)

I believe this fixes #179. 