### PR TITLE
Fix for MODX3

### DIFF
--- a/_build/resolvers/stercextra.resolver.php
+++ b/_build/resolvers/stercextra.resolver.php
@@ -17,7 +17,7 @@ $c->where(
         'workspace' => 1,
         "(SELECT
             `signature`
-            FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
+            FROM {$modx->getTableName('transport.modTransportPackage')} AS `latestPackage`
             WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
             ORDER BY
                 `latestPackage`.`version_major` DESC,


### PR DESCRIPTION
### What does it do?
Fix the getTableName method property, since it is not valid for MODX3