### PR TITLE
Change the stopforumspam api url

### DIFF
--- a/core/components/formit/src/FormIt/Service/StopForumSpam.php
+++ b/core/components/formit/src/FormIt/Service/StopForumSpam.php
@@ -24,7 +24,7 @@ class StopForumSpam
     {
         $this->modx = $modx;
         $this->config = array_merge([
-            'host' => 'http://api.stopforumspam.org/',
+            'host' => 'https://api.stopforumspam.com/',
             'path' => 'api',
             'method' => 'GET',
         ], $config);


### PR DESCRIPTION
### What does it do?
Change the stopforumspam url.

### Why is it needed?
http and org are deprecated according to https://www.stopforumspam.com/forum/viewtopic.php?pid=50695#p50695

Maybe the URL should be better configurable by a system setting.