### PR TITLE
Feature: Multi Page Form Support

### DIFF
--- a/core/components/formit/src/FormIt/Request.php
+++ b/core/components/formit/src/FormIt/Request.php
@@ -202,9 +202,32 @@ class Request
         $inPost = false;
         if (!empty($_POST)) {
             $inPost = true;
-            if (!empty($this->config['submitVar']) && empty($_POST[$this->config['submitVar']])) {
+            /*
+                Changed to provide means to allow multiple submit buttons in one form. The primary use case is multi-step/page forms,
+                where buttons used to navigate the form should post the current page data before moving to the specified step.
+                Each button of type submit should have a unique name that includes the value of the submitVar parameter, as well as
+                a value that differetiates the button's functionality. For example, in a chunk template the basic form navigation might be:
+
+                    <button type="submit" title="Previous" name="[[!+submitVar]]_prev" value="[[!+submitValPrev]]">Previous</button>
+                    <button type="submit" title="Next" name="[[!+submitVar]]>Next</button>
+                    <button type="submit" title="Last" name="[[!+submitVar]]_last" value="[[!+submitValLast]]">Skip to Last Step</button>
+
+                where the value is the step index to redirect to after submission (which would be optional for the regular submit button,
+                which is shown here as "Next").
+
+                This change should not require users to make changes to their existing forms.
+            */
+            if (!empty($this->config['submitVar'])) {
+                $keys = array_keys($_POST);
                 $inPost = false;
+                foreach ($keys as $key) {
+                    if (strpos($key, $this->config['submitVar']) !== false) {
+                        $inPost = true;
+                        break;
+                    }
+                }
             }
+
         }
 
         return $inPost;


### PR DESCRIPTION
### What does it do?
Changes how hasSubmission() is evaluated to allow multiple submit buttons to post the current form page (relevant in multi-step/page forms).

### Why is it needed?
Multi step forms that span multiple pages are currently not possible and need a mechanism to persist data across pages.

### Related issue(s)/PR(s)
There is a companion PR on the Formalicious repo ([PR 18](https://github.com/Sterc/Formalicious/pull/18))

### Example Form Template
To illustrate how this is set up, below is a template for a working form using the proposed feature. Note how the standard `submitVar` property is still used as it always has been, while additional buttons for navigating backward or to a specific step are appended with `_[postfix]`.
```
<form action="[[!+currentUrl]]" id="form-[[!+id]]" method="post" enctype="multipart/form-data">
	<div class="grid-container fluid">
        <div class="grid-x grid-padding-x">
			[[!+step
				:lt=`[[+formaliciousSteps]]`
				:then=`<div class="form-step-navigation">[[!+formalicious.navigation]]</div>`
				:else=``
			]]

    		[[!+formalicious.form]]

			<div class="form-pagination">
			[[!+step
				:neq=`1`
				:then=`
					<button type="submit" class="button btn--prev" title="[[%formalicious.prev? &namespace=`formalicious` &topic=`default`]]" name="[[!+submitVar]]_prev" value="[[!+submitValPrev]]">
        		[[%formalicious.prev? &namespace=`formalicious` &topic=`default`]]
		    		</button>
				`
				:else=``
			]]
    				<button type="submit" class="button btn--next" name="[[!+submitVar]]"  title="[[!+submitTitle]]">
	        		[[!+submitTitle]]
	    			</button>
			[[!+step
				:lt=`[[+formaliciousSteps]]`
				:then=`
					<button type="submit" class="button btn--last" title="Skip to Last Step" name="[[!+submitVar]]_last" value="[[!+submitValLast]]">Skip to Last Step</button>
				`
				:else=``
			]]
			</div>
		</div>
	</div>
</form>
```
