### PR TITLE
Fix for multiple checked boxes/multiselect on FormItLoadSavedForm

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitischecked.php
+++ b/core/components/formit/elements/snippets/snippet.formitischecked.php
@@ -34,7 +34,7 @@ $output = ' ';
 if ($input == $options) {
     $output = ' checked="checked"';
 }
-$input = $modx->fromJSON($input);
+$input = strpos($input, '"') ? $modx->fromJSON($input) : explode(',', $input);
 if (!empty($input) && is_array($input) && in_array($options,$input)) {
   $output = ' checked="checked"';
 }

--- a/core/components/formit/elements/snippets/snippet.formitisselected.php
+++ b/core/components/formit/elements/snippets/snippet.formitisselected.php
@@ -34,7 +34,7 @@ $output = ' ';
 if ($input == $options) {
     $output = ' selected="selected"';
 }
-$input = $modx->fromJSON($input);
+$input = strpos($input, '"') ? $modx->fromJSON($input) : explode(',', $input);
 if (!empty($input) && is_array($input) && in_array($options,$input)) {
   $output = ' selected="selected"';
 }


### PR DESCRIPTION
### What does it do?
Updated the `FormItIsChecked` and `FormItIsSelected` snippets to parse either a JSON array *or* a CSV

### Why is it needed?
If a group of checkboxes (or a multiselect) has multiple boxes checked (or multiple options selected) at save, no boxes are checked/selected when `FormItLoadSavedForm` loads the form because the data is not in a format the snippets could parse.

### Related issue(s)/PR(s)
Fixes #233 