### PR TITLE
Fix Argument 2 must be of type string

### DIFF
--- a/core/components/formit/src/FormIt/Hook/Email.php
+++ b/core/components/formit/src/FormIt/Hook/Email.php
@@ -94,8 +94,8 @@ class Email
 
         /* select email to */
         $emailSelectTo = $this->modx->getOption('emailSelectTo', $this->formit->config, '');
-        $emailSelectTo = ($emailSelectTo) ? explode(';', $emailSelectTo) : array();
         $emailSelectToName = $this->modx->getOption('emailSelectToName', $this->formit->config, $emailSelectTo);
+        $emailSelectTo = ($emailSelectTo) ? explode(';', $emailSelectTo) : array();
         $emailSelectToName = ($emailSelectToName) ? explode(';', $emailSelectToName) : array();
         $emailSelectField = $this->modx->getOption('emailSelectField', $this->formit->config, '');
         if ($emailSelectField && isset($fields[$emailSelectField])) {


### PR DESCRIPTION
### What does it do?/Why is it needed?

If the option emailSelectToName is not set, the option emailSelectTo is used. emailSelectTo was exploded before it was assigned to emailSelectToName. After that it is exploded again which causes the following issue in PHP 8.

```
PHP Fatal error:  Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, array given in /…/core/components/formit/src/FormIt/Hook/Email.php:99
```

The patch just reorders the assignment.