### PR TITLE
MODX 3: Fix namespace in FormItLoadSavedForm hook

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitloadsavedform.php
+++ b/core/components/formit/elements/snippets/snippet.formitloadsavedform.php
@@ -1,5 +1,5 @@
 <?php
-use FormItForm;
+use Sterc\FormIt\Model\FormItForm;
 
 /**
  * A custom FormIt prehook for fetching saved form data. - Based on FormItSaveForm


### PR DESCRIPTION
### What does it do?
Fixes the namespace for the class `FormItForm` in the "FormItLoadSavedForm" hook snippet.

### Why is it needed?
The hook creates an error in MODX 3 -> `Could not load class: FormItForm from mysql.formitform`.

### Related issue(s)/PR(s)
Resolves #285 
