### PR TITLE
Fix issue 271 for loading chunks via PDO

### DIFF
--- a/core/components/formit/src/FormIt.php
+++ b/core/components/formit/src/FormIt.php
@@ -343,7 +343,7 @@ class FormIt
      */
     public function getChunk($name, $properties = array())
     {
-        if (class_exists('pdoTools') && $pdo = $this->modx->getService('pdoTools')) {
+        if (class_exists('ModxPro\PdoTools\Fetch') && $pdo = $this->modx->getService('pdoTools')) {
             return $pdo->getChunk($name, $properties);
         }
 


### PR DESCRIPTION
### What does it do?
Fix issue 271 so chunks can be parsed via PDOTools again for filebase usage.

### Why is it needed?
Filebased structure would not be usable.

### Related issue(s)/PR(s)
Issue-271