### PR TITLE
Fix GROUP BY error if sql_mode "ONLY_FULL_GROUP_BY" is used [3.x]

### DIFF
--- a/core/components/formit/src/FormIt/Processors/Mgr/Encryption/GetList.php
+++ b/core/components/formit/src/FormIt/Processors/Mgr/Encryption/GetList.php
@@ -57,6 +57,7 @@ class GetList extends GetListProcessor
             ]);
         }
 
+        $criteria->select('MIN(id) AS id, form, context_key');
         $criteria->groupby('form');
         $criteria->groupby('context_key');
 
@@ -70,7 +71,7 @@ class GetList extends GetListProcessor
      */
     public function prepareRow(xPDOObject $object)
     {
-        return array_merge($object->toArray(), [
+        return array_merge($object->toArray('', false, true), [
             'encrypted'     => $this->modx->getCount($this->classKey, [
                 'form'          => $object->get('form'),
                 'context_key'   => $object->get('context_key'),
@@ -99,4 +100,3 @@ class GetList extends GetListProcessor
         return $contexts;
     }
 }
-

--- a/core/components/formit/src/FormIt/Processors/Mgr/Forms/GetForms.php
+++ b/core/components/formit/src/FormIt/Processors/Mgr/Forms/GetForms.php
@@ -63,6 +63,7 @@ class GetForms extends GetListProcessor
             'context_key:IN' => $this->getAvailableContexts()
         ]);
 
+        $criteria->select('MIN(id) AS id, form');
         $criteria->groupby('form');
 
         return $criteria;
@@ -75,7 +76,7 @@ class GetForms extends GetListProcessor
      */
     public function prepareRow(xPDOObject $object)
     {
-        return $object->toArray();
+        return $object->toArray('', false, true);
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Changes the SQL query to only include the columns the result is grouped by (plus the 'id' column).

### Why is it needed?
If the SQL-mode "ONLY_FULL_GROUP_BY" is used, the current code throws an error.

### Related issue(s)/PR(s)
Resolves #293 for the 3.x branch
