### PR TITLE
Fix GROUP BY error if sql_mode "ONLY_FULL_GROUP_BY" is used [2.x]

### DIFF
--- a/core/components/formit/processors/mgr/encryption/getlist.class.php
+++ b/core/components/formit/processors/mgr/encryption/getlist.class.php
@@ -72,9 +72,9 @@ class FormItGetListProcessor extends modObjectGetListProcessor
             );
         }
 
+        $criteria->select('MIN(id) AS id, form, context_key');
         $criteria->groupby('form');
         $criteria->groupby('context_key');
-        $criteria->groupby('id');
 
         return $criteria;
     }
@@ -87,7 +87,7 @@ class FormItGetListProcessor extends modObjectGetListProcessor
     public function prepareRow(xPDOObject $object)
     {
         return array_merge(
-            $object->toArray(), [
+            $object->toArray('', false, true), [
             'encrypted'     => $this->modx->getCount(
                 $this->classKey, [
                 'form'          => $object->get('form'),

--- a/core/components/formit/processors/mgr/forms/getforms.class.php
+++ b/core/components/formit/processors/mgr/forms/getforms.class.php
@@ -64,6 +64,7 @@ class FormItFormsGetListProcessor extends modObjectGetListProcessor
             'context_key:IN' => $this->getAvailableContexts()
         ]);
 
+        $criteria->select('MIN(id) AS id, form');
         $criteria->groupby('form');
 
         return $criteria;
@@ -76,7 +77,7 @@ class FormItFormsGetListProcessor extends modObjectGetListProcessor
      */
     public function prepareRow(xPDOObject $object)
     {
-        return $object->toArray();
+        return $object->toArray('', false, true);
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Changes the SQL query to only include the columns the result is grouped by (plus the 'id' column).

### Why is it needed?
If the SQL-mode "ONLY_FULL_GROUP_BY" is used, the current code throws an error.

### Related issue(s)/PR(s)
Resolves #293 for the 2.x branch.
Undoes the change from #281 (as I don't think it fixed the issue successfully).