### PR TITLE
Fix modMediaSource::load() is not a valid static method in MODX 3.x

### DIFF
--- a/core/components/formit/model/formit/formitform.class.php
+++ b/core/components/formit/model/formit/formitform.class.php
@@ -105,7 +105,7 @@ class FormItForm extends xPDOSimpleObject
 
         $error = '';
         $mediasourceId = $this->xpdo->getOption('formit.attachment.mediasource');
-        $mediasource = $this->xpdo->getObject('modMediaSource', $mediasourceId);
+        $mediasource = $this->xpdo->getObject('sources.modMediaSource', $mediasourceId);
         if (!$mediasource) {
             $error = $this->xpdo->lexicon('formit.storeAttachment_mediasource_error') . $mediasourceId;
         } else {


### PR DESCRIPTION
### What does it do?
Use a prefix to get the modMediaSource object.

### Why is it needed?
The code before works only in MODX 2.x and has issues in MODX 3.x
