### PR TITLE
Update delimiter fallback in CSV export function

### DIFF
--- a/_build/gpm.yml
+++ b/_build/gpm.yml
@@ -43,6 +43,9 @@ systemSettings:
   - key: max_chars_textfield
     area: formit
     value: 125
+  - key: export_csv_delimiter
+    area: formit
+    value: ;
 
 chunks:
   - name: fiDefaultEmailTpl

--- a/assets/components/formit/js/mgr/widgets/forms.grid.js
+++ b/assets/components/formit/js/mgr/widgets/forms.grid.js
@@ -513,7 +513,7 @@ FormIt.window.ExportForms = function(config) {
             name        : 'delimiter',
             anchor      : '100%',
             allowBlank  : false,
-            value       : ';'
+            value       : ''
         }, {
             xtype       : MODx.expandHelp ? 'label' : 'hidden',
             html        : _('formit.label_export_delimiter_desc'),

--- a/assets/components/formit/js/mgr/widgets/forms.grid.js
+++ b/assets/components/formit/js/mgr/widgets/forms.grid.js
@@ -513,7 +513,7 @@ FormIt.window.ExportForms = function(config) {
             name        : 'delimiter',
             anchor      : '100%',
             allowBlank  : false,
-            value       : ''
+            value       : MODx.config['formit.export_csv_delimiter']
         }, {
             xtype       : MODx.expandHelp ? 'label' : 'hidden',
             html        : _('formit.label_export_delimiter_desc'),

--- a/core/components/formit/src/FormIt/Processors/Mgr/Forms/Export.php
+++ b/core/components/formit/src/FormIt/Processors/Mgr/Forms/Export.php
@@ -209,7 +209,7 @@ class Export extends Processor
             $defaultColumns = array_map('strtolower', explode(',', $this->getProperty('columns')));
 
             if ($columns) {
-                fputcsv($fopen, $columns, $this->getProperty('delimiter'));
+                fputcsv($fopen, $columns, $this->getProperty('delimiter', $this->modx->getOption('formit.export_csv_delimiter')));
 
                 foreach ($data as $row) {
                     $value  = [];
@@ -231,7 +231,7 @@ class Export extends Processor
                         }
                     }
 
-                    fputcsv($fopen, $value, $this->getProperty('delimiter'));
+                    fputcsv($fopen, $value, $this->getProperty('delimiter', $this->modx->getOption('formit.export_csv_delimiter')));
                 }
             }
 


### PR DESCRIPTION
## Description
Change the export CSV delimiter via System Setting. See https://community.modx.com/t/how-to-tweak-some-formalicious-settings/9004/13.

## Testing
- [ ] Tested with custom delimiters
- [ ] Tested with default delimiter fallback

## Related Issues
Closes https://github.com/Sterc/Formalicious/issues/41