### PR TITLE
Upgrade reCAPTCHA v1 to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 Changelog for FormIt.
 
+# FormIt 5.2.1
+
+- Upgrade reCAPTCHA from v1 to v3.
+- Replace `recaptcha_public_key` / `recaptcha_private_key` system settings with `recaptcha_site_key` / `recaptcha_secret_key`.
+- Add `recaptcha_min_score` system setting (default: 0.5).
+- Add `recaptchaAction` snippet property to override the default reCAPTCHA action name.
+- Remove deprecated `recaptchaTheme`, `recaptchaJs`, `recaptcha_use_ssl` parameters.
+- Rewrite `formit.js`: AJAX and reCAPTCHA v3 token injection, CustomEvent-based public API.
+
 # FormIt 5.2.0
 
 - Add AJAX form submission support (#302)

--- a/_build/gpm.yml
+++ b/_build/gpm.yml
@@ -3,7 +3,7 @@ lowCaseName: formit
 description: FormIt is a dynamic form processing Snippet for MODx Revolution. It handles a form after submission, performing validation and followup actions like sending an email. It does not generate the form, but it can repopulate it if it fails validation.
 author: Sterc
 namespace: Sterc\FormIt
-version: 5.2.0
+version: 5.2.1
 
 build:
   setupOptions: "setup.options.php"
@@ -18,14 +18,13 @@ systemSettings:
     type: textfield
     area: general
     value:
-  - key: recaptcha_public_key
+  - key: recaptcha_site_key
     area: formit_recaptcha
-  - key: recaptcha_private_key
+  - key: recaptcha_secret_key
     area: formit_recaptcha
-  - key: recaptcha_use_ssl
+  - key: recaptcha_min_score
     area: formit_recaptcha
-    type: combo-boolean
-    value: 0
+    value: 0.5
   - key: exclude_contexts
     area: formit
     value: mgr
@@ -137,22 +136,9 @@ snippets:
         description: prop_formit.spamcheckip_desc
         type: combo-boolean
         value: "0"
-      - name: recaptchaJs
-        description: prop_formit.recaptchajs_desc
-        value: "{}"
-      - name: recaptchaTheme
-        description: prop_formit.recaptchatheme_desc
-        type: list
-        options:
-          - name: formit.opt_red
-            value: red
-          - name: formit.opt_white
-            value: white
-          - name: formit.opt_clean
-            value: clean
-          - name: formit.opt_blackglass
-            value: blackglass
-        value: clean
+      - name: recaptchaAction
+        description: prop_formit.recaptchaaction_desc
+        value:
       - name: redirectTo
         description: prop_formit.redirectto_desc
         value:

--- a/_build/gpm_scripts/gpm.script.reload_system_settings.php
+++ b/_build/gpm_scripts/gpm.script.reload_system_settings.php
@@ -11,9 +11,6 @@
  * @var array $options
  */
 
-use Fred\Model\FredThemedTemplate;
-use Fred\Model\FredBlueprint;
-use Fred\Model\FredTheme;
 use xPDO\Transport\xPDOTransport;
 use MODX\Revolution\modSystemSetting;
 use xPDO\xPDO;

--- a/assets/components/formit/js/web/formit.js
+++ b/assets/components/formit/js/web/formit.js
@@ -9,33 +9,24 @@
     'use strict';
 
     /**
+     * Global config. Set by PHP via Object.assign(FormIt, {...}).
+     */
+    window.FormIt = {
+        actionUrl: '/assets/components/formit/action.php',
+        recaptchaDefaultAction: 'submit'
+    };
+
+    /**
      * @param {HTMLFormElement} form
-     * @param {Object} [options]
      * @constructor
      */
-    function FormIt(form, options) {
+    function FormItForm(form) {
         if (!(form instanceof HTMLFormElement)) {
             console.error('[FormIt] First argument must be a form element.');
             return;
         }
 
         this.form = form;
-        this.options = {};
-
-        for (var key in FormIt.defaults) {
-            if (FormIt.defaults.hasOwnProperty(key)) {
-                this.options[key] = FormIt.defaults[key];
-            }
-        }
-
-        if (options) {
-            for (var key in options) {
-                if (options.hasOwnProperty(key)) {
-                    this.options[key] = options[key];
-                }
-            }
-        }
-
         this._lastSubmitter = null;
         this.form.addEventListener('click', this._onClickSubmit.bind(this));
         this.form.addEventListener('submit', this._onSubmit.bind(this));
@@ -46,31 +37,19 @@
      * @param {MouseEvent} e
      * @private
      */
-    FormIt.prototype._onClickSubmit = function (e) {
+    FormItForm.prototype._onClickSubmit = function (e) {
         var btn = e.target.closest('[type="submit"]');
         this._lastSubmitter = btn && btn.name ? btn : null;
-    };
-
-    /**
-     * Global defaults. actionUrl is set by PHP via regClientScript.
-     */
-    FormIt.defaults = {
-        actionUrl: '',
-        clearOnSuccess: true,
-        onBeforeSubmit: null,
-        onSuccess: null,
-        onError: null,
-        onComplete: null,
-        onRedirect: null
     };
 
     /**
      * @param {SubmitEvent} e
      * @private
      */
-    FormIt.prototype._onSubmit = function (e) {
-        if (!this.options.actionUrl) {
-            console.warn('[FormIt] actionUrl is not configured. Falling back to standard form submission.');
+    FormItForm.prototype._onSubmit = function (e) {
+        this.ajaxToken = this.form.getAttribute('data-formit-ajax-token');
+
+        if (!this.ajaxToken && !this.form.querySelector('[name="g-recaptcha-response"]')) {
             return;
         }
 
@@ -80,31 +59,79 @@
         var beforeEvent = this._dispatch('formit:beforesubmit', { form: this.form }, true);
         if (beforeEvent.defaultPrevented) return;
 
-        // callback
-        if (typeof this.options.onBeforeSubmit === 'function') {
-            if (this.options.onBeforeSubmit(this.form) === false) return;
-        }
-
-        this._clearMessages();
-        this._setLoading(true);
-
         var submitter = e.submitter || this._lastSubmitter || this.form.querySelector('[type="submit"]');
-        var formData = new FormData(this.form);
+        var formData  = new FormData(this.form);
 
-        // Include the submit button so server-side submitVar check works
         if (submitter && submitter.name) {
             formData.append(submitter.name, submitter.value || '');
         }
 
-        // Add ajaxToken from data-attribute
-        var token = this.form.getAttribute('data-formit-ajax-token');
-        if (token) {
-            formData.append('ajaxToken', token);
-        }
-
         var self = this;
 
-        fetch(this.options.actionUrl, {
+        // _resolveRecaptcha has its own guards — resolves immediately if not configured
+        this._resolveRecaptcha(formData)
+            .then(function () {
+                self._submit(formData);
+            })
+            .catch(function (error) {
+                console.error('[FormIt] reCAPTCHA failed:', error);
+                self._showMessage('[data-formit-error-message]', error.message || 'Request failed');
+                self._dispatch('formit:error', { data: null, error: error });
+            });
+    };
+
+    /**
+     * Execute reCAPTCHA v3 and fill both formData and the response field.
+     * Resolves immediately when reCAPTCHA is not configured.
+     *
+     * @param {FormData} formData
+     * @returns {Promise<void>}
+     * @private
+     */
+    FormItForm.prototype._resolveRecaptcha = function (formData) {
+        var recaptchaResponseField = this.form.querySelector('[name="g-recaptcha-response"]');
+
+        if (!recaptchaResponseField || typeof grecaptcha === 'undefined') {
+            return Promise.resolve();
+        }
+
+        var actionField     = this.form.querySelector('[name="g-recaptcha-action"]');
+        var recaptchaAction = (actionField && actionField.value) || FormIt.recaptchaDefaultAction;
+
+        return new Promise(function (resolve, reject) {
+            grecaptcha.ready(function () {
+                grecaptcha.execute(FormIt.recaptchaSiteKey, { action: recaptchaAction })
+                    .then(function (token) {
+                        recaptchaResponseField.value = token;
+                        formData.set('g-recaptcha-response', token);
+                        resolve();
+                    })
+                    .catch(reject);
+            });
+        });
+    };
+
+    /**
+     * Submit the form: native submit or AJAX fetch depending on ajaxToken.
+     *
+     * @param {FormData} formData
+     * @private
+     */
+    FormItForm.prototype._submit = function (formData) {
+        if (!this.ajaxToken) {
+            this.form.submit();
+            return;
+        }
+
+        formData.append('ajaxToken', this.ajaxToken);
+
+        this._clearMessages();
+        this._setLoading(true);
+
+        var self = this;
+        var form = this.form;
+
+        fetch(FormIt.actionUrl, {
             method: 'POST',
             headers: { 'X-Requested-With': 'XMLHttpRequest' },
             body: formData
@@ -129,21 +156,14 @@
             self._handleResponse(data);
         })
         .catch(function (error) {
-            console.error('[FormIt] Request failed:', error);
-
-            self._showMessage('[data-formit-error-message]', error.message || 'Request failed');
-
-            self._dispatch('formit:error', { data: null, error: error });
-            if (typeof self.options.onError === 'function') {
-                self.options.onError(null, error);
-            }
+            // AJAX failed — fall back to native submit so the request still goes through.
+            // reCAPTCHA token is already set in the response field value.
+            console.warn('[FormIt] AJAX failed, falling back to native submit:', error);
+            form.submit();
         })
         .finally(function () {
             self._setLoading(false);
             self._dispatch('formit:complete', {});
-            if (typeof self.options.onComplete === 'function') {
-                self.options.onComplete();
-            }
         });
     };
 
@@ -151,51 +171,35 @@
      * @param {Object} data - Response from processForm()
      * @private
      */
-    FormIt.prototype._handleResponse = function (data) {
-        var placeholders = data.placeholders || {};
+    FormItForm.prototype._handleResponse = function (data) {
+        var placeholders   = data.placeholders || {};
         var hasFieldErrors = false;
 
-        // Fill field errors
         for (var key in placeholders) {
             if (placeholders.hasOwnProperty(key) && key.indexOf('error.') === 0) {
                 hasFieldErrors = true;
-                var fieldName = key.substring(6); // Remove prefix "error."
+                var fieldName = key.substring(6);
                 var el = this.form.querySelector('[data-formit-error="' + fieldName + '"]');
                 if (el) el.innerHTML = placeholders[key];
             }
         }
 
-        // Fill messages with alert fallback
         this._showMessage('[data-formit-success-message]', placeholders.successMessage || '');
         this._showMessage('[data-formit-validation-error-message]', placeholders.validation_error_message || '');
         this._showMessage('[data-formit-error-message]', placeholders.error_message || '');
 
-        // Determine if this is an error response
         var isError = !data.success || hasFieldErrors || placeholders.validation_error || placeholders.error_message;
 
         if (isError) {
             this._dispatch('formit:error', { data: data });
-            if (typeof this.options.onError === 'function') {
-                this.options.onError(data);
-            }
         } else {
             this._dispatch('formit:success', { data: data });
-            if (typeof this.options.onSuccess === 'function') {
-                this.options.onSuccess(data);
-            }
 
-            if (this.options.clearOnSuccess) {
-                this.form.reset();
-            }
+            this.form.reset();
 
-            // Handle redirect (cancelable)
             if (data.redirect_url) {
                 var redirectEvent = this._dispatch('formit:redirect', { url: data.redirect_url }, true);
                 if (redirectEvent.defaultPrevented) return;
-
-                if (typeof this.options.onRedirect === 'function') {
-                    if (this.options.onRedirect(data.redirect_url) === false) return;
-                }
 
                 window.location.href = data.redirect_url;
             }
@@ -203,12 +207,11 @@
     };
 
     /**
-     * Show a message in a container element or fall back to alert.
      * @param {string} selector
      * @param {string} message
      * @private
      */
-    FormIt.prototype._showMessage = function (selector, message) {
+    FormItForm.prototype._showMessage = function (selector, message) {
         if (!message) return;
         var el = this.form.querySelector(selector);
         if (el) {
@@ -221,10 +224,9 @@
     };
 
     /**
-     * Clear all message and error elements in the form.
      * @private
      */
-    FormIt.prototype._clearMessages = function () {
+    FormItForm.prototype._clearMessages = function () {
         this.form.querySelectorAll('[data-formit-error]').forEach(function (el) {
             el.textContent = '';
         });
@@ -235,11 +237,10 @@
     };
 
     /**
-     * Toggle loading state on the form.
      * @param {boolean} loading
      * @private
      */
-    FormIt.prototype._setLoading = function (loading) {
+    FormItForm.prototype._setLoading = function (loading) {
         if (loading) {
             this.form.classList.add('formit-loading');
         } else {
@@ -253,14 +254,13 @@
     };
 
     /**
-     * Dispatch a CustomEvent on the form element.
      * @param {string} name
      * @param {Object} detail
      * @param {boolean} [cancelable]
      * @returns {CustomEvent}
      * @private
      */
-    FormIt.prototype._dispatch = function (name, detail, cancelable) {
+    FormItForm.prototype._dispatch = function (name, detail, cancelable) {
         var event = new CustomEvent(name, {
             detail: detail,
             bubbles: true,
@@ -270,15 +270,12 @@
         return event;
     };
 
-    // Auto-initialize
+    // Auto-initialize all forms
     document.addEventListener('DOMContentLoaded', function () {
-        var forms = document.querySelectorAll('form[data-formit-ajax-token]');
+        var forms = document.querySelectorAll('form');
         for (var i = 0; i < forms.length; i++) {
-            new FormIt(forms[i]);
+            new FormItForm(forms[i]);
         }
     });
-
-    // Expose globally
-    window.FormIt = FormIt;
 
 })(window, document);

--- a/core/components/formit/lexicon/cs/recaptcha.inc.php
+++ b/core/components/formit/lexicon/cs/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Nesprávná captcha slova. Zkontrolujte svou odpověď a zkuste to znovu.';
-$_lang['recaptcha.incorrect']                                   = 'reCAPTCHA nebyla zadána správně. Jděte zpět a zkuste to znovu. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Pro využívání reCAPTCHA Mailhide musíte mít nainstalovaný PHP modul "mcrypt".';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Pro využívání reCAPTCHA Mailhide se musíte zaregistrovat a tak získat veřejný a soukromý klíč, můžete tak učinit na adrese <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'reCAPTCHA nebyla zadána správně. Jděte zpět a zkuste to znovu.';
 $_lang['recaptcha.no_api_key']                                  = 'Pro využívání reCAPTCHA musíte získat klíč API na adrese <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'Z bezpečnostních důvodů, musíte zadat vzdálenou IP do reCAPTCHA';

--- a/core/components/formit/lexicon/de/recaptcha.inc.php
+++ b/core/components/formit/lexicon/de/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'reCAPTCHA-Eingabe leer. Bitte versuchen Sie es noch einmal.';
-$_lang['recaptcha.incorrect']                                   = 'reCAPTCHA-Worte falsch. Bitte überprüfen Sie die Eingabe und versuchen Sie es erneut. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Um reCAPTCHA Mailhide verwenden zu können, muss das mcrypt-PHP-Modul installiert sein.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Um reCAPTCHA Mailhide verwenden zu können, müssen Sie einen öffentlichen und einen privaten Schlüssel beantragen. Dies können Sie unter <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a> erledigen.';
+$_lang['recaptcha.incorrect']                                   = 'reCAPTCHA-Worte falsch. Bitte überprüfen Sie die Eingabe und versuchen Sie es erneut.';
 $_lang['recaptcha.no_api_key']                                  = 'Um reCAPTCHA verwenden zu können, benötigen Sie einen API-Schlüssel von <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>.';
-$_lang['recaptcha.no_remote_ip']                                = 'Aus Sicherheitsgründen muss die IP-Adresse an reCAPTCHA übertragen werden.';

--- a/core/components/formit/lexicon/en/recaptcha.inc.php
+++ b/core/components/formit/lexicon/en/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2020 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Incorrect captcha words. Please check your answer and try again.';
-$_lang['recaptcha.incorrect']                                   = 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'To use reCAPTCHA Mailhide, you have to sign up for a public and private key, you can do so at <a href="https://www.google.com/recaptcha" target="_blank">https://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again.';
 $_lang['recaptcha.no_api_key']                                  = 'To use reCAPTCHA you must get an API key from <a href="https://www.google.com/recaptcha" target="_blank">https://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'For security reasons, you must pass the remote IP to reCAPTCHA';

--- a/core/components/formit/lexicon/es/recaptcha.inc.php
+++ b/core/components/formit/lexicon/es/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Palabras de captcha incorrectas. Por favor revise sus datos y intentelo de nuevo.';
-$_lang['recaptcha.incorrect']                                   = 'El reCAPTCHA no fue introducido correctamente. Regrese a la pagina anterior y intentelo de nuevo. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Para utilizar reCAPTCHA Mailhide, necesita tener el módulo de php de mcrypt instalado.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Para utilizar reCAPTCHA Mailhide, necesita registrarse por una clave publica y privada, lo puede hacer en esta pagina <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'El reCAPTCHA no fue introducido correctamente. Regrese a la pagina anterior y intentelo de nuevo.';
 $_lang['recaptcha.no_api_key']                                  = 'Para utilizar reCAPTCHA necesita obtener una clave de API de <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'Por razones de seguridad, tiene que pasar el IP remoto a reCAPTCHA';

--- a/core/components/formit/lexicon/fr/recaptcha.inc.php
+++ b/core/components/formit/lexicon/fr/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Incorrect captcha words. Please check your answer and try again.';
-$_lang['recaptcha.incorrect']                                   = 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'To use reCAPTCHA Mailhide, you have to sign up for a public and private key, you can do so at <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again.';
 $_lang['recaptcha.no_api_key']                                  = 'To use reCAPTCHA you must get an API key from <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'For security reasons, you must pass the remote ip to reCAPTCHA';

--- a/core/components/formit/lexicon/it/recaptcha.inc.php
+++ b/core/components/formit/lexicon/it/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Parole della validazione non valide. Si prega di controllare la vostra risposta e riprovare.';
-$_lang['recaptcha.incorrect']                                   = 'La validazione non è stata immessa correttamente. Tornare indietro e riprovare. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Per utilizzare la validazione reCAPTCHA Mailhide, dovete avere il modulo PHP mcrypt installato.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Per utilizzare la validazione reCAPTCHA Mailhide, dovete iscrivervi per le chiavi pubbliche e private, potete farlo all\'indirizzo <a href="http://www.google.com/recaptcha/mailhide/">http://www.google.com/recaptcha/mailhide/</a>';
+$_lang['recaptcha.incorrect']                                   = 'La validazione non è stata immessa correttamente. Tornare indietro e riprovare.';
 $_lang['recaptcha.no_api_key']                                  = 'Per utilizzare la validazione reCAPTCHA dovete creare una chiave API da <a href="https://www.google.com/recaptcha/admin/create">https://www.google.com/recaptcha/admin/create</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'Per una questione di sicurezza, dovete si deve passare l\'IP remoto a reCAPTCHA';

--- a/core/components/formit/lexicon/nl/recaptcha.inc.php
+++ b/core/components/formit/lexicon/nl/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Captcha woorden onjuist. Controleer het antwoord en probeer het opnieuw.';
-$_lang['recaptcha.incorrect']                                   = 'De reCAPTCHA was niet (juist) ingevoerd. Ga terug en probeer het opnieuw. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'To use reCAPTCHA Mailhide, you have to sign up for a public and private key, you can do so at <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'De reCAPTCHA was niet (juist) ingevoerd. Ga terug en probeer het opnieuw.';
 $_lang['recaptcha.no_api_key']                                  = 'To use reCAPTCHA you must get an API key from <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'For security reasons, you must pass the remote ip to reCAPTCHA';

--- a/core/components/formit/lexicon/pl/recaptcha.inc.php
+++ b/core/components/formit/lexicon/pl/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Niepoprawne słowa captcha. Sprawdź swoją odpowiedź i spróbuj jeszcze raz.';
-$_lang['recaptcha.incorrect']                                   = 'Niepoprawne słowa captcha. Sprawdź swoją odpowiedź i spróbuj jeszcze raz. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Jeśli chcesz używać reCAPTCHA Mailhide, musisz mieć zainstalowany moduł mcrypt w php.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Jeśli chcesz używać reCAPTCHA Mailhide, musisz się zarejestrować i pobrać klucz prywatny i publiczny. Możesz to zrobić pod adresem <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'Niepoprawne słowa captcha. Sprawdź swoją odpowiedź i spróbuj jeszcze raz.';
 $_lang['recaptcha.no_api_key']                                  = 'Do używania reCAPTCHA musisz pobrać klucz API pod adresem <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'Ze względów bezpieczeństwa, należy wysłać zdalny adres ip do reCAPTCHA';

--- a/core/components/formit/lexicon/ru/recaptcha.inc.php
+++ b/core/components/formit/lexicon/ru/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2020 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Слова введены неправильно. Пожалуйста, проверьте ваш ответ и повторите попытку.';
-$_lang['recaptcha.incorrect']                                   = 'Слова с картинки введены неправильно. Пожалуйста, попробуйте ещё раз. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Для использования reCAPTCHA Mailhide у вас должен быть установлен PHP модуль mcrypt.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Для использования reCAPTCHA Mailhide, вам надо получить публичный и приватный ключи, это можно сделать на <a href="https://www.google.com/recaptcha" target="_blank">https://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'Слова с картинки введены неправильно. Пожалуйста, попробуйте ещё раз.';
 $_lang['recaptcha.no_api_key']                                  = 'Для использования reCAPTCHA вам надо получить API ключ на <a href="https://www.google.com/recaptcha" target="_blank">https://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'По соображениям безопасности, вы должны передать удаленный IP в reCAPTCHA';

--- a/core/components/formit/lexicon/sv/recaptcha.inc.php
+++ b/core/components/formit/lexicon/sv/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2019 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Incorrect captcha words. Please check your answer and try again.';
-$_lang['recaptcha.incorrect']                                   = 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'To use reCAPTCHA Mailhide, you have to sign up for a public and private key, you can do so at <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again.';
 $_lang['recaptcha.no_api_key']                                  = 'To use reCAPTCHA you must get an API key from <a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'For security reasons, you must pass the remote ip to reCAPTCHA';

--- a/core/components/formit/lexicon/uk/recaptcha.inc.php
+++ b/core/components/formit/lexicon/uk/recaptcha.inc.php
@@ -6,9 +6,5 @@
  * Copyright 2020 by Sterc <modx@sterc.nl>
  */
 
-$_lang['recaptcha.empty_answer']                                = 'Слова введені неправильно. Будь ласка, перевірте вашу відповідь і спробуйте ще раз.';
-$_lang['recaptcha.incorrect']                                   = 'Слова з картинки введені неправильно. Будь ласка, спробуйте ще раз. [[+error]]';
-$_lang['recaptcha.mailhide_no_mcrypt']                          = 'Для використання reCAPTCHA Mailhide у вас повинен бути встановлений PHP модуль mcrypt.';
-$_lang['recaptcha.mailhide_no_api_key']                         = 'Для використання reCAPTCHA Mailhide, вам треба отримати публічний і приватний ключі, це можна зробити на <a href="https://www.google.com/recaptcha" target="_blank">https://www.google.com/recaptcha</a>';
+$_lang['recaptcha.incorrect']                                   = 'Слова з картинки введені неправильно. Будь ласка, спробуйте ще раз.';
 $_lang['recaptcha.no_api_key']                                  = 'Для використання reCAPTCHA вам треба отримати API ключ на <a href="https://www.google.com/recaptcha" target="_blank">https://www.google.com/recaptcha</a>';
-$_lang['recaptcha.no_remote_ip']                                = 'З міркувань безпеки, ви повинні передати віддалений IP в reCAPTCHA';

--- a/core/components/formit/src/FormIt.php
+++ b/core/components/formit/src/FormIt.php
@@ -16,6 +16,8 @@ use Sterc\FormIt\Model\FormItForm;
 
 class FormIt
 {
+    const DEFAULT_RECAPTCHA_ACTION = 'submit';
+
     /**
      * @access public.
      * @var \modX.

--- a/core/components/formit/src/FormIt/Hook/Recaptcha.php
+++ b/core/components/formit/src/FormIt/Hook/Recaptcha.php
@@ -50,26 +50,18 @@ class Recaptcha
      */
     public function process()
     {
-        $passed = false;
         /** @var RecaptchaService $reCaptcha */
         $reCaptcha = $this->formit->request->loadReCaptcha();
-        if (empty($reCaptcha->config[RecaptchaService::OPT_PRIVATE_KEY])) {
+        if (empty($reCaptcha->config[RecaptchaService::OPT_SECRET_KEY])) {
             $this->hook->addError('recaptcha', $this->modx->lexicon('recaptcha.no_api_key'));
             return false;
         }
 
-        $response = $reCaptcha->checkAnswer(
-            $_SERVER['REMOTE_ADDR'],
-            $_POST['recaptcha_challenge_field'] ?? '',
-            $_POST['recaptcha_response_field'] ?? ''
-        );
+        $token  = $_POST['g-recaptcha-response'] ?? '';
+        $passed = $reCaptcha->verify($token);
 
-        if (!$response->is_valid) {
-            $this->hook->addError('recaptcha', $this->modx->lexicon('recaptcha.incorrect', array(
-                'error' => (!empty($response->error) && $response->error != 'incorrect-captcha-sol') ? $response->error : '',
-            )));
-        } else {
-            $passed = true;
+        if (!$passed) {
+            $this->hook->addError('recaptcha', $this->modx->lexicon('recaptcha.incorrect'));
         }
 
         return $passed;

--- a/core/components/formit/src/FormIt/Request.php
+++ b/core/components/formit/src/FormIt/Request.php
@@ -159,8 +159,29 @@ class Request
             if (!empty($frontendJs)) {
                 $assetsUrl = $this->formit->config['assets_url'];
                 $this->modx->regClientScript($assetsUrl . $frontendJs);
-                $this->modx->regClientScript('<script>FormIt.defaults.actionUrl='
-                    . json_encode($assetsUrl . 'action.php') . ';</script>', true);
+
+                $jsConfig = ['actionUrl' => $assetsUrl . 'action.php'];
+
+                /* add reCAPTCHA v3 config if hook is active and site key is set */
+                if (!empty($this->reCaptcha) && $this->reCaptcha instanceof RecaptchaService) {
+                    $siteKey = $this->reCaptcha->config[RecaptchaService::OPT_SITE_KEY] ?? '';
+                    if (!empty($siteKey)) {
+                        $this->modx->regClientStartupScript(
+                            'https://www.google.com/recaptcha/api.js?render=' . urlencode($siteKey)
+                        );
+                        $jsConfig['recaptchaSiteKey'] = $siteKey;
+                        $jsConfig['recaptchaDefaultAction'] = $this->modx->getOption(
+                            'recaptchaAction',
+                            $this->config,
+                            \Sterc\FormIt::DEFAULT_RECAPTCHA_ACTION
+                        );
+                    }
+                }
+
+                $this->modx->regClientScript(
+                    '<script>Object.assign(FormIt,' . json_encode($jsConfig) . ');</script>',
+                    true
+                );
             }
         }
 

--- a/core/components/formit/src/FormIt/Service/RecaptchaService.php
+++ b/core/components/formit/src/FormIt/Service/RecaptchaService.php
@@ -1,271 +1,122 @@
 <?php
 namespace Sterc\FormIt\Service;
 
+use MODX\Revolution\modX;
+
 class RecaptchaService
 {
-    const API_SERVER = 'http://www.google.com/recaptcha/api/';
-    const API_SECURE_SERVER = 'https://www.google.com/recaptcha/api/';
-    const VERIFY_SERVER = 'www.google.com';
-    const OPT_PRIVATE_KEY = 'privateKey';
-    const OPT_PUBLIC_KEY = 'publicKey';
-    const OPT_USE_SSL = 'use_ssl';
+    const VERIFY_URL     = 'https://www.google.com/recaptcha/api/siteverify';
+    const OPT_SITE_KEY   = 'siteKey';
+    const OPT_SECRET_KEY = 'secretKey';
+    const OPT_MIN_SCORE  = 'minScore';
 
-    /** @var modX $modX */
+    /** @var modX $modx */
     public $modx;
-    /** @var FormIt $formit */
+    /** @var \Sterc\FormIt $formit */
     public $formit;
+    /** @var array $config */
+    public $config = [];
 
-    public function __construct($formit, array $config = array())
+    public function __construct($formit, array $config = [])
     {
         $this->formit = $formit;
-        $this->modx = $formit->modx;
+        $this->modx   = $formit->modx;
         $this->modx->lexicon->load('formit:recaptcha');
-        $this->config = array_merge(array(
-            self::OPT_PRIVATE_KEY => $this->modx->getOption('formit.recaptcha_private_key', $config, ''),
-            self::OPT_PUBLIC_KEY => $this->modx->getOption('formit.recaptcha_public_key', $config, ''),
-            self::OPT_USE_SSL => $this->modx->getOption('formit.recaptcha_use_ssl', $config, false),
-        ), $config);
+        $this->config = array_merge([
+            self::OPT_SITE_KEY   => $this->modx->getOption('formit.recaptcha_site_key',   $config, ''),
+            self::OPT_SECRET_KEY => $this->modx->getOption('formit.recaptcha_secret_key', $config, ''),
+            self::OPT_MIN_SCORE  => (float) $this->modx->getOption('formit.recaptcha_min_score', $config, 0.5),
+        ], $config);
     }
 
     /**
-     * Encodes the given data into a query string format
-     * @param $data - array of string elements to be encoded
-     * @return string - encoded request
-     */
-    protected function qsencode($data) {
-        $req = '';
-        foreach ($data as $key => $value) {
-            $req .= $key . '=' . urlencode( stripslashes($value) ) . '&';
-        }
-
-        // Cut the last '&'
-        $req=substr($req,0,strlen($req)-1);
-        return $req;
-    }
-
-    /**
-     * Submits an HTTP POST to a reCAPTCHA server
-     * @param string $host
-     * @param string $path
-     * @param array $data
-     * @param int $port
-     * @return array response
-     */
-    protected function httpPost($host, $path, array $data = array(), $port = 80) {
-        $data['privatekey'] = $this->config[self::OPT_PRIVATE_KEY];
-        $req = $this->qsencode($data);
-
-        $http_request  = "POST $path HTTP/1.0\r\n";
-        $http_request .= "Host: $host\r\n";
-        $http_request .= "Content-Type: application/x-www-form-urlencoded;\r\n";
-        $http_request .= "Content-Length: " . strlen($req) . "\r\n";
-        $http_request .= "User-Agent: reCAPTCHA/PHP\r\n";
-        $http_request .= "\r\n";
-        $http_request .= $req;
-
-        $response = '';
-        if(false == ($fs = @fsockopen($host, $port, $errno, $errstr, 10))) {
-            return 'Could not open socket';
-        }
-
-        fwrite($fs, $http_request);
-        while (!feof($fs)) {
-            $response .= fgets($fs, 1160); // One TCP-IP packet
-        }
-        fclose($fs);
-        $response = explode("\r\n\r\n", $response, 2);
-
-        return $response;
-    }
-
-    /**
-     * Gets the challenge HTML (javascript and non-javascript version).
-     * This is called from the browser, and the resulting reCAPTCHA HTML widget
-     * is embedded within the HTML form it was called from.
+     * Renders two hidden fields required for reCAPTCHA v3.
+     * The Google API JS must be registered separately via Request.php.
      *
      * @param array $scriptProperties
-     * @return string - The HTML to be embedded in the user's form.
+     * @return string HTML with two hidden inputs
      */
-    public function render($scriptProperties = array()) {
-        if (empty($this->config[self::OPT_PUBLIC_KEY])) {
+    public function render(array $scriptProperties = []): string
+    {
+        if (empty($this->config[self::OPT_SITE_KEY])) {
             return $this->error($this->modx->lexicon('recaptcha.no_api_key'));
         }
 
-        /* use ssl or not */
-        $server = !empty($this->config[self::OPT_USE_SSL]) ? self::API_SECURE_SERVER : self::API_SERVER;
+        $action = htmlspecialchars(
+            (string) $this->modx->getOption('recaptchaAction', $scriptProperties, ''),
+            ENT_QUOTES
+        );
 
-        $opt = $this->getOptions($scriptProperties);
-        $html = '<script type="text/javascript">var RecaptchaOptions = '.$this->modx->toJSON($opt).';</script><script type="text/javascript" src="'. $server . 'challenge?k=' . $this->config[self::OPT_PUBLIC_KEY] . '"></script>
-<noscript><div>
-        <object data="'. $server . 'noscript?k=' . $this->config[self::OPT_PUBLIC_KEY] . '" height="'.$opt['height'].'" width="'.$opt['width'].'" style="width: '.$opt['width'].'px; height: '.$opt['height'].'px;"></object>
-        <textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
-        <input type="hidden" name="recaptcha_response_field" value="manual_challenge"/></div>
-</noscript>';
-        $this->modx->setPlaceholder('formit.recaptcha_html',$html);
-        $this->modx->setPlaceholder($scriptProperties['placeholderPrefix'].'recaptcha_html',$html);
+        $html = '<input type="hidden" name="g-recaptcha-response" value="">'
+              . '<input type="hidden" name="g-recaptcha-action" value="' . $action . '">';
+
+        $this->modx->setPlaceholder('formit.recaptcha_html', $html);
+        if (!empty($scriptProperties['placeholderPrefix'])) {
+            $this->modx->setPlaceholder($scriptProperties['placeholderPrefix'] . 'recaptcha_html', $html);
+        }
+
         return $html;
     }
 
     /**
-     * Get options for reCaptcha from snippet
+     * Verifies a reCAPTCHA v3 token via Google Siteverify API.
      *
-     * @param array $scriptProperties
-     * @return array|void
+     * @param string $token The token from g-recaptcha-response POST field
+     * @return bool True if verification passed and score >= minScore
      */
-    public function getOptions(array $scriptProperties = array()) {
-        $opt = $this->modx->getOption('recaptchaJs',$scriptProperties,'{}');
-        $opt = $this->modx->fromJSON($opt);
-        if (empty($opt)) $opt = array();
+    public function verify(string $token): bool
+    {
+        if (empty($this->config[self::OPT_SECRET_KEY])) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[FormIt] reCAPTCHA: secret key not configured');
+            return false;
+        }
 
-        /* backwards compat */
-        $backwardOpt = array(
-            'theme' => $this->modx->getOption('recaptchaTheme',$scriptProperties,'clean'),
-            'width' => $this->modx->getOption('recaptchaWidth',$scriptProperties,500),
-            'height' => $this->modx->getOption('recaptchaHeight',$scriptProperties,300),
-            'lang' => $this->modx->getOption('cultureKey',null,'en'),
-        );
-        $opt = array_merge($backwardOpt,$opt);
+        if (empty($token)) {
+            return false;
+        }
 
-        return $opt;
+        $payload = http_build_query([
+            'secret'   => $this->config[self::OPT_SECRET_KEY],
+            'response' => $token,
+            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+        ]);
+
+        $ch = curl_init(self::VERIFY_URL);
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $payload,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => 10,
+            CURLOPT_HTTPHEADER     => ['Content-Type: application/x-www-form-urlencoded'],
+        ]);
+        $raw = curl_exec($ch);
+        $err = curl_error($ch);
+        unset($ch);
+
+        if ($raw === false || $err) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[FormIt] reCAPTCHA curl error: ' . $err);
+            return false;
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data) || empty($data['success'])) {
+            return false;
+        }
+
+        $score    = isset($data['score']) ? (float) $data['score'] : 0.0;
+        $minScore = (float) $this->config[self::OPT_MIN_SCORE];
+
+        return $score >= $minScore;
     }
 
     /**
-     * State there is an error with reCaptcha
+     * Returns an error string.
+     *
      * @param string $message
      * @return string
      */
-    protected function error($message = '') {
+    protected function error(string $message = ''): string
+    {
         return $message;
-    }
-
-    /**
-     * Calls an HTTP POST function to verify if the user's guess was correct
-     * @param string $remoteIp
-     * @param string $challenge
-     * @param string $responseField
-     * @param array $extraParams An array of extra variables to post to the server
-     * @return \Sterc\FormIt\Service\RecaptchaResponse
-     */
-    public function checkAnswer ($remoteIp, $challenge, $responseField, $extraParams = array()) {
-        $response = new RecaptchaResponse();
-        $response->is_valid = false;
-
-        if (empty($this->config[self::OPT_PRIVATE_KEY])) {
-            $response->error = $this->modx->lexicon('recaptcha.no_api_key');
-            return $response;
-        }
-
-        if (empty($remoteIp)) {
-            $response->error = $this->modx->lexicon('recaptcha.no_remote_ip');
-            return $response;
-        }
-
-        //discard spam submissions
-        if (empty($challenge) || empty($responseField)) {
-            $response->error = $this->modx->lexicon('recaptcha.empty_answer');
-            return $response;
-        }
-
-        $httpResponse = $this->httpPost(self::VERIFY_SERVER, "/recaptcha/api/verify", array (
-            'remoteip' => $remoteIp,
-            'challenge' => $challenge,
-            'response' => $responseField,
-        ) + $extraParams);
-
-        $answers = explode("\n", $httpResponse[1] ?? '');
-
-        if (trim($answers[0]) == 'true') {
-            $response->is_valid = true;
-        } else {
-            $response->error = $answers[1] ?? '';
-        }
-        return $response;
-    }
-
-    /**
-     * Gets a URL where the user can sign up for reCAPTCHA. If your application
-     * has a configuration page where you enter a key, you should provide a link
-     * using this function.
-     *
-     * @param string $domain The domain where the page is hosted
-     * @param string $appname The name of your application
-     * @return string
-     */
-    public function getSignupUrl($domain = null,$appname = null) {
-        return "http://recaptcha.net/api/getkey?" .  $this->qsencode(array ('domain' => $domain, 'app' => $appname));
-    }
-
-    protected function aesPad($val) {
-        $block_size = 16;
-        $numpad = $block_size - (strlen ($val) % $block_size);
-        return str_pad($val, strlen ($val) + $numpad, chr($numpad));
-    }
-
-    /* Mailhide related code */
-    protected function aesEncrypt($val,$ky) {
-        if (!function_exists("mcrypt_encrypt")) {
-            return $this->error($this->modx->lexicon('recaptcha.mailhide_no_mcrypt'));
-        }
-        $mode=MCRYPT_MODE_CBC;
-        $enc=MCRYPT_RIJNDAEL_128;
-        $val= $this->aesPad($val);
-        return mcrypt_encrypt($enc, $ky, $val, $mode, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
-    }
-
-
-    protected function mailhideUrlbase64($x) {
-        return strtr(base64_encode ($x), '+/', '-_');
-    }
-
-    /* gets the reCAPTCHA Mailhide url for a given email, public key and private key */
-    public function mailhideUrl($email) {
-        if (empty($this->config[self::OPT_PUBLIC_KEY]) || empty($this->config[self::OPT_PRIVATE_KEY])) {
-            return $this->error($this->modx->lexicon('recaptcha.mailhide_no_api_key'));
-        }
-
-        $ky = pack('H*',$this->config[self::OPT_PRIVATE_KEY]);
-        $cryptmail = $this->aesEncrypt($email, $ky);
-        return 'http://mailhide.recaptcha.net/d?k='
-               . $this->config[self::OPT_PUBLIC_KEY]
-               . '&c=' . $this->mailhideUrlbase64($cryptmail);
-    }
-
-    /**
-     * Gets the parts of the email to expose to the user.
-     * eg, given johndoe@example,com return ["john", "example.com"].
-     * the email is then displayed as john...@example.com
-     *
-     * @param string $email
-     * @return array|string
-     */
-    public function mailhideEmailParts ($email) {
-        $arr = preg_split("/@/", $email);
-
-        if (strlen($arr[0]) <= 4) {
-            $arr[0] = substr($arr[0], 0, 1);
-        } else if (strlen ($arr[0]) <= 6) {
-            $arr[0] = substr($arr[0], 0, 3);
-        } else {
-            $arr[0] = substr($arr[0], 0, 4);
-        }
-        return $arr;
-    }
-
-    /**
-     * Gets html to display an email address given a public an private key.
-     * to get a key, go to:
-     *
-     * http://mailhide.recaptcha.net/apikey
-     *
-     * @param $email
-     * @return string
-     */
-    public function mailhideHtml($email) {
-        $emailparts = $this->mailhideEmailParts($email);
-        $url = $this->mailhideUrl($email);
-
-        $str = htmlentities($emailparts[0]) . "<a href='" . htmlentities ($url) .
-               "' onclick=\"window.open('" . htmlentities ($url) . "', '', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=500,height=300'); return false;\" title=\"Reveal this e-mail address\">...</a>@" . htmlentities($emailparts [1]);
-        return $str;
     }
 }


### PR DESCRIPTION
### What does it do?
Upgrades reCAPTCHA integration from v1 to v3

### Why is it needed?
reCAPTCHA v1 was shut down by Google in 2018 and has not worked since. The integration was completely non-functional.

### Related issue(s)/PR(s)
—