### PR TITLE
Fix recaptcha v3 issues when using hcaptcha as the captcha provider

### DIFF
--- a/assets/components/formit/js/web/formit.js
+++ b/assets/components/formit/js/web/formit.js
@@ -95,7 +95,7 @@
     FormItForm.prototype._resolveRecaptcha = function (formData) {
         var recaptchaResponseField = this.form.querySelector('[name="g-recaptcha-response"]');
 
-        if (!recaptchaResponseField || typeof grecaptcha === 'undefined') {
+        if (!recaptchaResponseField || typeof grecaptcha === 'undefined' || typeof window.hcaptcha === 'object') {
             return Promise.resolve();
         }
 


### PR DESCRIPTION
### What does it do?
This adds an additional case to the javascript resolver when using hcaptcha instead of recaptcha. hcaptcha is a privacy respecting captcha provider, and it's supposed to be a drop in replacement for recaptcha.

### Why is it needed?
On sites where we have FormIt installed and are using hCaptcha, the newest versions of FormIt assume reCaptcha v3. This is throwing an error on form submission "grecaptcha.ready is not a function". I can see how you have code in place to check for the presence of an element with the name attribute set to g-recaptcha-response, and if it doesn't exist, then to resolve the promise and move on. However, the ready property is not set by hcaptcha, so it appears that hcaptcha is only a valid "drop in replacement" with v1 or v2 reCaptcha. This change just checks to see if there is an hcaptcha object on the window, and if so, resolve the promise so that it falls back to the old school way of doing things.

### Related issue(s)/PR(s)
Not that I can see.